### PR TITLE
Add MCP sandtimer server and Windows release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Build Windows executable
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install pyinstaller
+
+      - name: Build executable
+        shell: pwsh
+        run: |
+          pyinstaller --onefile --name mcp-sandtimer src/mcp_sandtimer/__main__.py
+          $version = "${{ github.ref_name }}"
+          $output = "dist\\mcp-sandtimer.exe"
+          if (Test-Path $output) {
+            Rename-Item -Path $output -NewName "mcp-sandtimer-$version.exe"
+          }
+
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/mcp-sandtimer-${{ github.ref_name }}.exe
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyc
+build/
+dist/
+*.spec
+.venv/
+.DS_Store

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+# MCP Sandtimer Server
+
+This repository contains a Python implementation of a local [Model Context Protocol](https://github.com/modelcontextprotocol) (MCP) server that exposes the **sandtimer** desktop application through MCP tools. The server forwards JSON commands to the sandtimer TCP listener running on `127.0.0.1:61420`, allowing ChatGPT or any MCP compatible client to control the GUI timer application.
+
+## Features
+
+- Implements the MCP handshake and tool interfaces entirely over STDIO.
+- Provides three tools: `start_timer`, `reset_timer`, and `cancel_timer`.
+- Validates user input and forwards commands to sandtimer using TCP sockets.
+- Packaged as a standalone executable for Windows via PyInstaller during tagged releases.
+
+## Project Structure
+
+```
+src/
+└── mcp_sandtimer/
+    ├── __init__.py
+    ├── __main__.py
+    └── server.py
+```
+
+## Running locally
+
+Create a virtual environment and install the project in editable mode:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+Run the MCP server (ensure that the sandtimer application is already running and listening on the default port):
+
+```bash
+python -m mcp_sandtimer
+```
+
+The server communicates using STDIO, so it can be launched by ChatGPT or any MCP-compatible client. The included tools are:
+
+| Tool | Parameters | Description |
+| --- | --- | --- |
+| `start_timer` | `label` (string), `time` (number of seconds) | Creates or restarts a timer with the provided duration. |
+| `reset_timer` | `label` (string) | Resets an existing timer to its original duration. |
+| `cancel_timer` | `label` (string) | Cancels and closes the timer window. |
+
+## Sandtimer integration
+
+Each tool invocation generates a JSON command that is sent to the sandtimer process through TCP. The commands follow this shape:
+
+```json
+{ "cmd": "start", "label": "example", "time": 60 }
+```
+
+```json
+{ "cmd": "reset", "label": "example" }
+```
+
+```json
+{ "cmd": "cancel", "label": "example" }
+```
+
+If the sandtimer service is not reachable, the MCP tool will return an error to the client.
+
+## Packaging and releases
+
+When a tag starting with `v` (for example `v1.0.0`) is pushed, GitHub Actions automatically:
+
+1. Checks out the repository on a Windows runner.
+2. Installs the project dependencies and PyInstaller.
+3. Builds a single-file executable containing the MCP server and its dependencies.
+4. Uploads the resulting executable as an asset attached to the GitHub release that GitHub automatically creates for the tag.
+
+The workflow definition lives in [`.github/workflows/release.yml`](.github/workflows/release.yml).
+
+## License
+
+Released under the MIT License. See [LICENSE](LICENSE) for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "mcp-sandtimer"
+version = "0.1.0"
+description = "Local MCP server that controls the sandtimer application over TCP."
+readme = "README.md"
+authors = [{ name = "MCP Developer" }]
+license = { text = "MIT" }
+requires-python = ">=3.9"
+dependencies = []
+
+[project.scripts]
+mcp-sandtimer = "mcp_sandtimer.__main__:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# Runtime dependencies for the MCP sandtimer server

--- a/src/mcp_sandtimer/__init__.py
+++ b/src/mcp_sandtimer/__init__.py
@@ -1,0 +1,5 @@
+"""MCP server exposing sandtimer TCP interface."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/mcp_sandtimer/__main__.py
+++ b/src/mcp_sandtimer/__main__.py
@@ -1,0 +1,10 @@
+"""Executable entrypoint for running the MCP server."""
+from .server import serve
+
+
+def main() -> None:
+    serve()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp_sandtimer/server.py
+++ b/src/mcp_sandtimer/server.py
@@ -1,0 +1,327 @@
+"""Core logic for the sandtimer MCP server."""
+from __future__ import annotations
+
+import json
+import socket
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+from . import __version__
+
+JsonDict = Dict[str, Any]
+
+
+class MCPError(Exception):
+    """Base error for MCP responses."""
+
+
+class ToolExecutionError(MCPError):
+    """Raised when a tool cannot be executed."""
+
+
+@dataclass
+class Tool:
+    """Represents a registered tool."""
+
+    name: str
+    description: str
+    schema: JsonDict
+    handler: Callable[[JsonDict], str]
+
+
+class SandtimerClient:
+    """Thin TCP client responsible for talking to the sandtimer service."""
+
+    def __init__(self, host: str = "127.0.0.1", port: int = 61420, timeout: float = 5.0) -> None:
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+
+    def _send(self, payload: JsonDict) -> None:
+        message = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+        with socket.create_connection((self.host, self.port), timeout=self.timeout) as conn:
+            conn.sendall(message)
+
+    def start(self, label: str, seconds: int) -> None:
+        self._send({"cmd": "start", "label": label, "time": seconds})
+
+    def reset(self, label: str) -> None:
+        self._send({"cmd": "reset", "label": label})
+
+    def cancel(self, label: str) -> None:
+        self._send({"cmd": "cancel", "label": label})
+
+
+class MCPServer:
+    """A very small MCP compatible JSON-RPC server."""
+
+    protocol_version = "2024-05-14"
+
+    def __init__(self, client: Optional[SandtimerClient] = None) -> None:
+        self._client = client or SandtimerClient()
+        self._tools: Dict[str, Tool] = {}
+        self._initialized = False
+        self._write_lock = threading.Lock()
+        self._register_builtin_tools()
+        self._pending_ready_notification: Optional[JsonDict] = None
+
+    def _register_builtin_tools(self) -> None:
+        self.register_tool(
+            Tool(
+                name="start_timer",
+                description="Start or restart a named sand timer.",
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string",
+                            "description": "Human readable timer name.",
+                        },
+                        "time": {
+                            "type": "number",
+                            "description": "Duration of the timer in seconds.",
+                            "minimum": 1,
+                        },
+                    },
+                    "required": ["label", "time"],
+                },
+                handler=self._handle_start_timer,
+            )
+        )
+
+        self.register_tool(
+            Tool(
+                name="reset_timer",
+                description="Reset an existing sand timer to its original duration.",
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string",
+                            "description": "Timer name to reset.",
+                        }
+                    },
+                    "required": ["label"],
+                },
+                handler=self._handle_reset_timer,
+            )
+        )
+
+        self.register_tool(
+            Tool(
+                name="cancel_timer",
+                description="Cancel and close a sand timer window.",
+                schema={
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "type": "string",
+                            "description": "Timer name to cancel.",
+                        }
+                    },
+                    "required": ["label"],
+                },
+                handler=self._handle_cancel_timer,
+            )
+        )
+
+    def register_tool(self, tool: Tool) -> None:
+        self._tools[tool.name] = tool
+
+    # Tool handlers -----------------------------------------------------------------
+    def _handle_start_timer(self, arguments: JsonDict) -> str:
+        label = self._validate_label(arguments.get("label"))
+        seconds_value = arguments.get("time")
+        if not isinstance(seconds_value, (int, float)):
+            raise ToolExecutionError("'time' must be a number of seconds.")
+        seconds = int(seconds_value)
+        if seconds <= 0:
+            raise ToolExecutionError("'time' must be greater than zero.")
+        try:
+            self._client.start(label, seconds)
+        except OSError as exc:  # pragma: no cover - network interaction
+            raise ToolExecutionError(f"Failed to reach sandtimer service: {exc}") from exc
+        return f"Timer '{label}' started for {seconds} seconds."
+
+    def _handle_reset_timer(self, arguments: JsonDict) -> str:
+        label = self._validate_label(arguments.get("label"))
+        try:
+            self._client.reset(label)
+        except OSError as exc:  # pragma: no cover - network interaction
+            raise ToolExecutionError(f"Failed to reach sandtimer service: {exc}") from exc
+        return f"Timer '{label}' reset."
+
+    def _handle_cancel_timer(self, arguments: JsonDict) -> str:
+        label = self._validate_label(arguments.get("label"))
+        try:
+            self._client.cancel(label)
+        except OSError as exc:  # pragma: no cover - network interaction
+            raise ToolExecutionError(f"Failed to reach sandtimer service: {exc}") from exc
+        return f"Timer '{label}' canceled."
+
+    @staticmethod
+    def _validate_label(label: Any) -> str:
+        if not isinstance(label, str) or not label.strip():
+            raise ToolExecutionError("'label' must be a non-empty string.")
+        return label.strip()
+
+    # JSON-RPC plumbing --------------------------------------------------------------
+    def serve_forever(self) -> None:
+        """Start serving requests over STDIO."""
+        stdin = sys.stdin
+        while True:
+            line = stdin.readline()
+            if not line:
+                break
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                message = json.loads(line)
+            except json.JSONDecodeError:
+                self._send_error(None, code=-32700, message="Parse error")
+                continue
+            response = self._handle_message(message)
+            if response is not None:
+                self._write_json(response)
+
+    def _handle_message(self, message: JsonDict) -> Optional[JsonDict]:
+        if not isinstance(message, dict):
+            return self._make_error(None, -32600, "Invalid request")
+
+        message_id = message.get("id")
+        method = message.get("method")
+        if method:
+            params = message.get("params", {})
+            if not isinstance(params, dict):
+                params = {}
+            if method == "initialize":
+                result = self._handle_initialize(params)
+                if message_id is not None:
+                    return {
+                        "jsonrpc": "2.0",
+                        "id": message_id,
+                        "result": result,
+                    }
+                return None
+            if method == "tools/list":
+                result = self._handle_tools_list()
+                if message_id is not None:
+                    return {
+                        "jsonrpc": "2.0",
+                        "id": message_id,
+                        "result": result,
+                    }
+                return None
+            if method == "tools/call":
+                if message_id is None:
+                    return None
+                try:
+                    result = self._handle_tools_call(params)
+                    return {
+                        "jsonrpc": "2.0",
+                        "id": message_id,
+                        "result": {
+                            "content": [
+                                {"type": "text", "text": result}
+                            ]
+                        },
+                    }
+                except ToolExecutionError as exc:
+                    return self._make_error(message_id, -32002, str(exc))
+                except Exception as exc:  # pragma: no cover - safeguard
+                    return self._make_error(message_id, -32099, f"Unexpected error: {exc}")
+            if method in {"ping", "shutdown"}:
+                if message_id is not None:
+                    return {
+                        "jsonrpc": "2.0",
+                        "id": message_id,
+                        "result": {"time": time.time()} if method == "ping" else {},
+                    }
+                return None
+            if method.startswith("notifications/"):
+                return None
+            if message_id is not None:
+                return self._make_error(message_id, -32601, f"Method '{method}' not found")
+            return None
+        # If it is a response, ignore.
+        return None
+
+    def _handle_initialize(self, params: JsonDict) -> JsonDict:
+        protocol_version = params.get("protocolVersion") or self.protocol_version
+        self._initialized = True
+        self._pending_ready_notification = {
+            "jsonrpc": "2.0",
+            "method": "notifications/server/ready",
+            "params": {
+                "protocolVersion": protocol_version,
+                "capabilities": {"tools": {"list": True, "call": True}},
+            },
+        }
+        return {
+            "protocolVersion": protocol_version,
+            "serverInfo": {"name": "sandtimer-mcp", "version": __version__},
+            "capabilities": {
+                "tools": {"list": True, "call": True},
+            },
+        }
+
+    def _handle_tools_list(self) -> JsonDict:
+        tools = [
+            {
+                "name": tool.name,
+                "description": tool.description,
+                "inputSchema": tool.schema,
+            }
+            for tool in self._tools.values()
+        ]
+        return {"tools": tools}
+
+    def _handle_tools_call(self, params: JsonDict) -> str:
+        if not self._initialized:
+            raise ToolExecutionError("Server has not been initialized yet.")
+        name = params.get("name")
+        if not isinstance(name, str):
+            raise ToolExecutionError("Invalid tool name.")
+        arguments = params.get("arguments")
+        if arguments is None:
+            arguments = {}
+        if not isinstance(arguments, dict):
+            raise ToolExecutionError("Tool arguments must be an object.")
+        tool = self._tools.get(name)
+        if tool is None:
+            raise ToolExecutionError(f"Tool '{name}' is not available.")
+        return tool.handler(arguments)
+
+    def _make_error(self, message_id: Any, code: int, message: str) -> JsonDict:
+        return {"jsonrpc": "2.0", "id": message_id, "error": {"code": code, "message": message}}
+
+    def _send_error(self, message_id: Any, code: int, message: str) -> None:
+        self._write_json(self._make_error(message_id, code, message))
+
+    def _write_json(self, payload: JsonDict) -> None:
+        text = json.dumps(payload, ensure_ascii=False)
+        with self._write_lock:
+            sys.stdout.write(text + "\n")
+            sys.stdout.flush()
+        self._flush_pending_notifications()
+
+    def _flush_pending_notifications(self) -> None:
+        if self._pending_ready_notification is not None:
+            notification = self._pending_ready_notification
+            self._pending_ready_notification = None
+            with self._write_lock:
+                sys.stdout.write(json.dumps(notification, ensure_ascii=False) + "\n")
+                sys.stdout.flush()
+
+
+def serve() -> None:
+    """Entry point helper used by the CLI."""
+    server = MCPServer()
+    server.serve_forever()
+
+
+__all__ = ["MCPServer", "serve"]


### PR DESCRIPTION
## Summary
- implement a Python MCP server that communicates with the sandtimer TCP service and exposes start, reset, and cancel tools
- add a module entrypoint and packaging metadata for local execution and distribution
- configure a Windows GitHub Actions workflow to build a PyInstaller executable and attach it to tagged releases

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d5052f0888832f9d81c5e9fbc6faba